### PR TITLE
IPS-Variablen leeren, falls keine weitere TV-Aufnahme geplant ist.

### DIFF
--- a/IPS-Tvheadend/module.php
+++ b/IPS-Tvheadend/module.php
@@ -108,6 +108,11 @@ class IPS_Tvheadend extends IPSModule
                 SetValue($this->GetIDForIdent('TVHNextRecording'),$title);
                 SetValue($this->GetIDForIdent('TVHNextRecordingStartTime'),$startTime);
                 SetValue($this->GetIDForIdent('TVHNextRecordingEndTime'),$endTime);
+            } else {
+                SetValue($this->GetIDForIdent('TVHNextRecordingChannel'),'');
+                SetValue($this->GetIDForIdent('TVHNextRecording'),'Keine Aufnahme geplant');
+                SetValue($this->GetIDForIdent('TVHNextRecordingStartTime'),0);
+                SetValue($this->GetIDForIdent('TVHNextRecordingEndTime'),0); 
             }
         }
     }


### PR DESCRIPTION
Sofern keine geplante Aufnahme mehr existiert sollten die IPS-Variablen geleert werden.